### PR TITLE
[서비스] 마이페이지-orderlist

### DIFF
--- a/backend/model/mypage_dao.py
+++ b/backend/model/mypage_dao.py
@@ -40,13 +40,12 @@ class MyPageDao:
                     AND
                         q.parent_id is NULL
                 """
-
+            # 답변/미답변 필터링 조건 존재 시
             if 'answer' in answer:
-                status = answer['answer']
-                print('???????????????', status)
+                answer = answer['answer']
                 q_info += """
                     AND
-                        q.is_finished = %(status)s
+                        q.is_finished = %(answer)s
                     """
             q_info += """
                 ORDER BY
@@ -58,6 +57,138 @@ class MyPageDao:
                 LIMIT {limit}
                 OFFSET {offset}
             """
-            cursor.execute(q_info, {'user_id' : user_id, 'status' : status})
+
+            cursor.execute(q_info, {'user_id' : user_id, 'answer' : answer})
             q_list = cursor.fetchall()
+          
             return q_list
+
+    def mypage_qna_count(self, connection, user_id, answer):
+        with connection.cursor(pymysql.cursors.DictCursor) as cursor:            
+            q_count = """
+                SELECT
+                    COUNT(*)
+                FROM
+                    qnas AS q
+                    LEFT JOIN qnas AS qna_r
+                        ON q.id = qna_r.parent_id
+                    LEFT JOIN user_info AS seller
+                        ON qna_r.replier_id = seller.id
+                    JOIN user_info AS u
+                        ON q.writer_id = u.id
+                    JOIN question_types AS qt
+                        ON q.question_type_id=qt.id
+                WHERE
+                    q.is_delete = 0
+                    AND
+                        u.id = %(user_id)s
+                    AND
+                        q.parent_id is NULL
+                """
+            # 답변/미답변 필터링 조건 존재 시
+            if 'answer' in answer:
+                answer = answer['answer']
+                q_count += """
+                    AND
+                        q.is_finished = %(answer)s
+                    """
+            cursor.execute(q_count, {'user_id' : user_id, 'answer' : answer})
+            q_counting = cursor.fetchall()
+
+            return q_counting
+
+
+
+    def mypage_order_header_dao(self, connection, user_id, page_condition):
+        limit = page_condition['limit']
+        offset = page_condition['offset']
+        with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+            order_header_info = """
+                SELECT
+                    o.id,
+                    o.created_at,
+                    o.order_number
+                FROM
+                    orders AS o
+                WHERE
+                    o.is_delete = 0
+                AND
+                    o.user_id = %(user_id)s
+                """
+
+            order_header_info += f"""
+                LIMIT {limit}
+                OFFSET {offset}
+            """
+            cursor.execute(order_header_info, {'user_id' : user_id})
+            order_header_list = cursor.fetchall()
+
+            return order_header_list
+
+
+    def mypage_order_cart_dao(self, connection, user_id, page_condition, order_id):
+        with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+            order_info = """
+                SELECT
+                    c.id,
+                    p.name,
+                    color.name,
+                    size.name,
+                    c.quantity,
+                    c.order_id,
+                    o.order_number AS orderNumber,
+                    s.korean_brand_name AS brand,
+                    s.user_info_id AS sId,
+                    c.order_id AS cartOrderId
+                FROM
+                    carts AS c
+                JOIN
+                    orders AS o
+                ON
+                    c.order_id = o.id
+                LEFT JOIN
+                    product_options AS po
+                ON
+                    c.product_option_id = po.id
+                JOIN
+                    products AS p
+                ON
+                    po.product_id = p.id
+                JOIN
+                    sellers AS s
+                ON
+                    p.seller_id = s.user_info_id
+                JOIN
+                    product_size_types AS size
+                ON
+                    po.product_size_type_id = size.id
+                JOIN
+                    product_color_types AS color
+                ON
+                    po.product_color_type_id = color.id
+                WHERE
+                    o.user_id = %(user_id)s
+                AND
+                    c.order_id IN %(order_id)s
+            """
+
+            cursor.execute(order_info, {'user_id' : user_id, 'order_id' : order_id})
+            order_list = cursor.fetchall()
+            return order_list
+
+    def mypage_order_count(self, connection, user_id):
+        with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+            order_count = """
+                SELECT
+                    COUNT(*)
+                FROM
+                    orders AS o
+                WHERE
+                    o.is_delete = 0
+                AND
+                    o.user_id = %(user_id)s
+                """
+            cursor.execute(order_count, {'user_id' : user_id})
+            order_counting = cursor.fetchall()
+
+            return order_counting

--- a/backend/service/mypage_service.py
+++ b/backend/service/mypage_service.py
@@ -7,24 +7,59 @@ class MyPageService:
     def mypage_qna(self, connection, user_id, page_condition, answer):
         mypage_dao = MyPageDao()
         mypage_qna = mypage_dao.mypyage_qna_dao(connection, user_id, page_condition, answer)
+        #totalCount 수 반환
+        mypage_count = mypage_dao.mypage_qna_count(connection, user_id, answer)[0]
+        total_count = mypage_count['COUNT(*)']
 
         result = []
-        for i in mypage_qna:
-            a = {
-                'id' : i['id'],
-                'username' : i['username'],
-                'contents' : i['contents'],
-                'category' : i['category'],
-                'created_at' : i['created_at']
+        for row in mypage_qna:
+            question = {
+                'id'            : row['id'],
+                'username'      : row['username'],
+                'contents'      : row['contents'],
+                'category'      : row['category'],
+                'created_at'    : row['created_at']
             }
             # 답변이 있는경우 answer에 담아줌
-            if i['answer_id']:
-                a['answer'] = {
-                    'id': i['answer_id'],
-                    'replier': i['answer_replier'],
-                    'content': i['answer_content'],
-                    'created_at': i['answer_time'],
-                    'parent_id': i['answer_parent']
+            if row['answer_id']:
+                question['answer'] = {
+                    'id'            : row['answer_id'],
+                    'replier'       : row['answer_replier'],
+                    'content'       : row['answer_content'],
+                    'created_at'    : row['answer_time'],
+                    'parent_id'     : row['answer_parent']
                 }
-            result.append(a)
-        return {"data" : result}
+            result.append(question)
+        return {"data" : result, "totalCount" : total_count}
+
+    def mypage_order(self, connection, user_id, page_condition):
+        mypage_dao = MyPageDao()
+        #totalCount수 반환
+        order_count = mypage_dao.mypage_order_count(connection, user_id)[0]
+        total_count = order_count['COUNT(*)']
+
+        # 로그인 유저의 주문 목록 반환
+        order_header = mypage_dao.mypage_order_header_dao(connection, user_id, page_condition)
+        order_id = [o['id'] for o in order_header]
+        
+        # 해당되는 주문목록에 속하는 구매 목록 반환
+        order_cart = mypage_dao.mypage_order_cart_dao(connection, user_id, page_condition, order_id)
+        order_list = [{
+            "ordernum" : order_head['order_number'],
+            "ordertime" : order_head['created_at'],
+            'product': []
+        } for order_head in order_header]
+
+        for cart in order_cart:
+            order_num = cart['orderNumber']
+            brand = cart['brand']
+            order = list(filter(lambda d: d['ordernum'] == order_num,  order_list))[0]
+            option_brand = list(filter(lambda d: d['brand'] == brand,  order['product']))
+            if not option_brand:
+                option_brand = {'brand': brand, 'option':[]}
+                order['product'].append(option_brand)
+            else:
+                option_brand = option_brand[0]
+            option_brand['option'].append(cart)
+
+        return {"data" : order_list, "totalCount" : total_count}

--- a/backend/view/mypage_view.py
+++ b/backend/view/mypage_view.py
@@ -42,3 +42,33 @@ class MyPageView:
         finally:
             if connection is not None:
                 connection.close
+
+    @mypage_app.route('/order', methods=['GET'])
+    def mypage_order():
+        page_condition = {}
+
+        user_id = request.headers['Authorization']
+        limit   = request.args.get('limit', None)
+        offset  = request.args.get('offset', None)
+
+        if limit is None:
+            page_condition['limit'] = 5
+        else:
+            page_condition['limit'] = int(limit)
+        if offset is None:
+            page_condition['offset'] = 0
+        else:
+            page_condition['offset'] = int(offset)
+
+        try:
+            connection      = connect_db()
+            mypage_service  = MyPageService()
+            extra           = mypage_service.mypage_order(connection, user_id, page_condition)
+            return extra
+        except Exception as e:
+            if connection:
+                connection.rollback()
+            raise e
+        finally:
+            if connection is not None:
+                connection.close()


### PR DESCRIPTION
- 로그인한 유저의 주문내역list
- 여러개의 주문내역에 해당하는 각각의 상품들을 담는다
- 같은 브랜드의 상품내역일 경우 브랜드 명으로 묶인다
- list 하나 선택시 주문상세페이지로 이동되도록 주문내역의 id를 함께 반환한다.
- totalCount라는 키값에는 조건에 해당되는 data의 전체 갯수를 담는다